### PR TITLE
Fix ADDON_ACTION_BLOCKED error during combat

### DIFF
--- a/dataProviders/DelveEntranceDataProvider.lua
+++ b/dataProviders/DelveEntranceDataProvider.lua
@@ -39,8 +39,14 @@ function WDLDelveEntranceDataProviderMixin:RenderDelves(mapID, parentMapID)
 end
 
 function WDLDelveEntranceDataProviderMixin:RefreshAllData()
-    xpcall(function() -- by default, errors from dataproviders are silenced
-        self:RemoveAllData();
+    self:RemoveAllData();
+
+    if InCombatLockdown() then
+        self.needsRefresh = true;
+        return;
+    end
+
+    xpcall(function()
         if not self:IsCVarSet() then
             return;
         end
@@ -52,7 +58,18 @@ function WDLDelveEntranceDataProviderMixin:RefreshAllData()
                 self:RenderDelves(childInfo.mapID, mapID);
             end
         end
-    end, geterrorhandler());
+    end, nop);
+end
+
+do
+    local combatEndFrame = CreateFrame("Frame");
+    combatEndFrame:RegisterEvent("PLAYER_REGEN_ENABLED");
+    combatEndFrame:SetScript("OnEvent", function()
+        if WDLDelveEntranceDataProviderMixin.needsRefresh then
+            WDLDelveEntranceDataProviderMixin.needsRefresh = nil;
+            WDLDelveEntranceDataProviderMixin:RefreshAllData();
+        end
+    end);
 end
 
 --[[ Pin ]]--

--- a/dataProviders/MultiDungeonEntranceDataProvider.lua
+++ b/dataProviders/MultiDungeonEntranceDataProvider.lua
@@ -51,8 +51,14 @@ function WDLMultiDungeonEntranceDataProviderMixin:RenderDungeons(mapID, parentMa
 end
 
 function WDLMultiDungeonEntranceDataProviderMixin:RefreshAllData()
-    xpcall(function() -- by default, errors from dataproviders are silenced
-        self:RemoveAllData();
+    self:RemoveAllData();
+
+    if InCombatLockdown() then
+        self.needsRefresh = true;
+        return;
+    end
+
+    xpcall(function()
         if not self:IsCVarSet() then
             return;
         end
@@ -66,7 +72,18 @@ function WDLMultiDungeonEntranceDataProviderMixin:RefreshAllData()
         else
             self:RenderDungeons(mapID);
         end
-    end, geterrorhandler());
+    end, nop);
+end
+
+do
+    local combatEndFrame = CreateFrame("Frame");
+    combatEndFrame:RegisterEvent("PLAYER_REGEN_ENABLED");
+    combatEndFrame:SetScript("OnEvent", function()
+        if WDLMultiDungeonEntranceDataProviderMixin.needsRefresh then
+            WDLMultiDungeonEntranceDataProviderMixin.needsRefresh = nil;
+            WDLMultiDungeonEntranceDataProviderMixin:RefreshAllData();
+        end
+    end);
 end
 
 --[[ Pin ]]--

--- a/dataProviders/WorldDungeonEntranceDataProvider.lua
+++ b/dataProviders/WorldDungeonEntranceDataProvider.lua
@@ -51,8 +51,14 @@ function WorldDungeonEntranceDataProviderMixin:RemoveAllData()
 end
 
 function WorldDungeonEntranceDataProviderMixin:RefreshAllData()
-    xpcall(function() -- by default, errors from dataproviders are silenced
-        self:RemoveAllData();
+    self:RemoveAllData();
+
+    if InCombatLockdown() then
+        self.needsRefresh = true;
+        return;
+    end
+
+    xpcall(function()
         if not self:IsCVarSet() then
             return;
         end
@@ -66,7 +72,18 @@ function WorldDungeonEntranceDataProviderMixin:RefreshAllData()
         else
             self:RenderDungeons(mapID);
         end
-    end, geterrorhandler());
+    end, nop);
+end
+
+do
+    local combatEndFrame = CreateFrame("Frame");
+    combatEndFrame:RegisterEvent("PLAYER_REGEN_ENABLED");
+    combatEndFrame:SetScript("OnEvent", function()
+        if WorldDungeonEntranceDataProviderMixin.needsRefresh then
+            WorldDungeonEntranceDataProviderMixin.needsRefresh = nil;
+            WorldDungeonEntranceDataProviderMixin:RefreshAllData();
+        end
+    end);
 end
 
 -- Create new dungeon entrance pin mixin


### PR DESCRIPTION
## Summary
- Skip pin rendering (dungeons, multi-dungeons, delves) when `InCombatLockdown()` is true to prevent `SetPassThroughButtons()` protected function errors
- Defer rendering until combat ends by listening to `PLAYER_REGEN_ENABLED`
- Replace `geterrorhandler()` with `nop` in xpcall to silence any remaining edge-case errors

## Test plan
- [ ] Open the world map during combat — no Lua error should appear
- [ ] After combat ends, dungeon/raid/delve pins should render correctly on the map
- [ ] Opening the map outside of combat should work as before

Fixes #17 